### PR TITLE
stats div の内部ではなくその直前に diff-stars span を挿入するように修正

### DIFF
--- a/BeatSaver.js
+++ b/BeatSaver.js
@@ -87,14 +87,23 @@ function core(){
                                 }
                                 var stats=difficultyItem.querySelector('.stats');
                                 console.log(stats);
+                                
                                 var starSpan=document.createElement('span');
                                 starSpan.classList.add('diff-stars');
                                 starSpan.textContent='('+starNumber+')';
+                                starSpan.style.margin = '0px auto';
+                                starSpan.style.paddingLeft = '5px';
+                                starSpan.style.paddingRight = '5px';
+                                starSpan.style.paddingTop = '0px';
+                                starSpan.style.paddingBottom = '0px';
+                                starSpan.style.textAlign = 'center';
+                                
                                 var starI=document.createElement('i');
                                 starI.classList.add('fas');
                                 starI.classList.add('fa-star')
                                 starSpan.prepend(starI);
-                                stats.prepend(starSpan);
+
+                                difficultyItem.insertBefore(starSpan, stats);
                             }
                         })
                     }


### PR DESCRIPTION
Fixed #1 

## Summary
統計情報表示枠の溢れによる表示の崩れを修正

## Changes
- `starSpan` のスタイルを修正
- `starSpan` の挿入箇所を `stats` の内部から `stats` の直前に変更

## 修正後のスクリーンショット
### 大幅表示
![image](https://user-images.githubusercontent.com/87169907/160996883-7c3a1540-d921-43a1-9657-8d9abf79ec9f.png)

### 中幅表示
![image](https://user-images.githubusercontent.com/87169907/160996866-63df0556-77cc-4467-87c5-7d80d8e5b24d.png)

### 小幅表示
![image](https://user-images.githubusercontent.com/87169907/160996846-fd6f1f16-10ef-4aac-94cb-c263ed624132.png)
